### PR TITLE
Multiple fixes (listed inside)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
 before_install:
   - sudo apt-get update
   - sudo apt install clamav-daemon
+  - sudo service clamav-freshclam stop
+  - sudo service clamav-daemon stop
+  - sudo freshclam
   - sudo service clamav-daemon start
 install:
   - composer update

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,9 @@ before_install:
   - sudo apt-get update
   - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
-  - sudo service clamav-daemon stop
-  - sudo mkdir -p /var/run/clamav
-  - sudo touch /var/run/clamav/clamd.ctl
-  - sudo chown clamav:clamav /var/run/clamav/clamd.ctl
+  - sudo service clamav-daemon restart
   - sudo freshclam
-  - sudo service clamav-daemon start
+  - sudo service clamav-daemon restart
 install:
   - composer update
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - '8.0'
 before_install:
   - sudo apt-get update
-  - sudo apt install clamav clamav-daemon
+  - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop
   - sudo freshclam

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: bionic
 php:
   - '7.2'
   - '7.3'
+  - '7.4'
+  - '8.0'
 before_install:
   - sudo apt-get update
   - sudo apt install clamav-daemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
   - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop
+  - sudo touch /var/run/clamav/clamd.ctl
+  - sudo chown clamav:clamav /var/run/clamav/clamd.ctl
   - sudo freshclam
   - sudo service clamav-daemon start
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ php:
 before_install:
   - sudo apt-get update
   - sudo apt install clamav-daemon
-  - sudo service clamav-freshclam stop
-  - sudo service clamav-daemon stop
-  - sudo freshclam
   - sudo service clamav-daemon start
 install:
   - composer update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: focal
+dist: bionic
 php:
   - '7.2'
   - '7.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop
-  - cat /etc/clamd.conf
+  - cat /etc/clamav/clamd.conf
   - sudo touch /var/run/clamav/clamd.ctl
   - sudo chown clamav:clamav /var/run/clamav/clamd.ctl
   - sudo freshclam

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - '8.0'
 before_install:
   - sudo apt-get update
+  - sudo apt-get purge clamav
   - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop
-  - cat /etc/clamav/clamd.conf
+  - sudo mkdir -p /var/run/clamav
   - sudo touch /var/run/clamav/clamd.ctl
   - sudo chown clamav:clamav /var/run/clamav/clamd.ctl
   - sudo freshclam

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: bionic
+dist: focal
 php:
   - '7.2'
   - '7.3'
@@ -7,7 +7,6 @@ php:
   - '8.0'
 before_install:
   - sudo apt-get update
-  - sudo apt-get purge clamav
   - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - '8.0'
 before_install:
   - sudo apt-get update
-  - sudo apt install clamav-daemon
+  - sudo apt install clamav clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop
   - sudo freshclam

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt install clamav-daemon
   - sudo service clamav-freshclam stop
   - sudo service clamav-daemon stop
+  - cat /etc/clamd.conf
   - sudo touch /var/run/clamav/clamd.ctl
   - sudo chown clamav:clamav /var/run/clamav/clamd.ctl
   - sudo freshclam

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Scans uploaded files for viruses and other malware",
     "type": "library",
     "require": {
-        "laravel/framework": "^5.1||^6.0||^7.0",
+        "laravel/framework": "^5.1||^6.0||^7.0||^8.0",
         "php": ">=7.2",
         "xenolope/quahog": "^2.1"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,6 @@
     <testsuites>
         <testsuite name="Unit Tests">
             <directory suffix="Test.php">./tests/Unit</directory>
-            <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
- Allow Laravel 8.
- Extend test coverage to PHP 7.4 and 8.0.
- Remove nonexistent directory from PHPUnit configuration.
- Fix ClamAV socket not being available during tests.